### PR TITLE
Rename our 'menu' class to not be affected by XTools' CSS

### DIFF
--- a/wikilabels/wsgi/static/css/home.css
+++ b/wikilabels/wsgi/static/css/home.css
@@ -16,29 +16,34 @@ text-align: right;
 float: right;
 }
 
-#wikilabels-home > .menu {
+#wikilabels-home > .menu,
+#wikilabels-home > .wikilabels-menu {
   margin-left: 26em;
   text-align: center;
   width: auto;
   height: 20em;
   border-left: 1px solid silver;
 }
-html[dir="rtl"] #wikilabels-home > .menu {
+html[dir="rtl"] #wikilabels-home > .menu,
+html[dir="rtl"] #wikilabels-home > .wikilabels-menu {
   margin-left: 0em;
   border-left: 0px;
   margin-right: 26em;
   border-right: 1px solid silver;
 }
-#wikilabels-home > .menu > .connector {
+#wikilabels-home > .menu > .connector,
+#wikilabels-home > .wikilabels-menu > .connector {
   font-size: 200%;
   padding-top: 2em;
 }
-#wikilabels-home > .menu > .campaign-list {
+#wikilabels-home > .menu > .campaign-list,
+#wikilabels-home > .wikilabels-menu > .campaign-list {
   height: 100%;
   overflow: auto;
   line-height: 1;
 }
-#wikilabels-home > .menu > .campaign-list .container {
+#wikilabels-home > .menu > .campaign-list .container,
+#wikilabels-home > .wikilabels-menu > .campaign-list .container {
   padding: .5ex;
 }
 #wikilabels-home .campaign-list > .container > .campaign {

--- a/wikilabels/wsgi/static/css/workspace.css
+++ b/wikilabels/wsgi/static/css/workspace.css
@@ -17,15 +17,18 @@
   margin-top: 0em;
 }
 
-.wikilabels-workspace > .menu {
+.wikilabels-workspace > .menu,
+.wikilabels-workspace > .wikilabels-menu {
   text-align: right;
   margin-bottom: .5em;
 }
-html[dir="rtl"] .wikilabels-workspace > .menu {
+html[dir="rtl"] .wikilabels-workspace > .menu,
+html[dir="rtl"] .wikilabels-workspace > .wikilabels-menu {
   text-align: left;
 }
 
-.wikilabels-workspace > .menu > .fullscreen .oo-ui-labelElement-label {
+.wikilabels-workspace > .menu > .fullscreen .oo-ui-labelElement-label,
+.wikilabels-workspace > .wikilabels-menu > .fullscreen .oo-ui-labelElement-label {
   line-height: .9em;
 }
 

--- a/wikilabels/wsgi/static/js/wikiLabels/Home.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/Home.js
@@ -23,9 +23,9 @@
 		this.$element = $element;
 		WL.Home.instances.push(this)
 
-		this.$menu = this.$element.find("> .menu");
+		this.$menu = this.$element.find("> .menu, > .wikilabels-menu");
 		if ( this.$menu === undefined || this.$menu.length !== 1 ) {
-			throw "#" + WL.config.prefix + "home > .menu must be a single defined element";
+			throw "#" + WL.config.prefix + "home > .wikilabels-menu must be a single defined element";
 		}
 
 

--- a/wikilabels/wsgi/static/js/wikiLabels/Workspace.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/Workspace.js
@@ -13,7 +13,7 @@
 
 		this.$parent = $element.parent();
 
-		this.$menu = $('<div>').addClass( 'menu');
+		this.$menu = $('<div>').addClass( 'wikilabels-menu' );
 		this.$element.append(this.$menu);
 		this.fullscreenToggle = new OO.ui.ToggleButtonWidget( {
 			label: WL.i18n('fullscreen'),

--- a/wikilabels/wsgi/templates/gadget.html
+++ b/wikilabels/wsgi/templates/gadget.html
@@ -20,7 +20,7 @@
           <li><a rel="nofollow" class="external text" href="https://github.com/halfak/Wiki-Labels">github repo</a></li>
           </ul>
         </div>
-        <div class="menu"
+        <div class="wikilabels-menu"
              style=" ">
           <div style="padding-top: 2em;">
             <span style="font-size: 200%;">OMG button</span>


### PR DESCRIPTION
See
* [meta:User talk:Hedonil/XTools#CSS_class is too generic](https://meta.wikimedia.org/wiki/User_talk:Hedonil/XTools#CSS_class_is_too_generic)
* [w:pt:Wikipédia Discussão:Projetos/Rotulagem/Qualidade das edições#Problema ao instalar o script](https://pt.wikipedia.org/wiki/Wikip%C3%A9dia_Discuss%C3%A3o:Projetos/Rotulagem/Qualidade_das_edi%C3%A7%C3%B5es#Problema_ao_instalar_o_script)
* https://github.com/x-Tools/xtools/blob/c8db3cbcee5ad6dab6739aaba217d625b35ffecd/public_html/api.php#L111